### PR TITLE
fix: replace azurenoops telemetry URL (closes #9)

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -65,7 +65,7 @@ locals {
   "outputs": {
     "telemetry": {
       "type": "String",
-      "value": "For more information, see https://aka.ms/azurenoops/tf/telemetry"
+      "value": "For more information, see https://aka.ms/POps-Rox/tf/telemetry"
     }
   }
 }


### PR DESCRIPTION
Fixes #9.

Updates the telemetry identifier URL in `locals.tf` (line 68) to reference the canonical `POps-Rox` repo instead of the legacy `azurenoops` module path.

**Change:**
```diff
-      "value": "For more information, see https://aka.ms/azurenoops/tf/telemetry"
+      "value": "For more information, see https://aka.ms/POps-Rox/tf/telemetry"
```

Separate from the open slug-correction PR — touches only the telemetry URL string in `locals.tf`, not any module source slugs.

**Validation:**
- `terraform init -backend=false` — OK
- `terraform validate` — Success! The configuration is valid.
- `grep -rln azurenoops --include=*.tf --include=*.md .` — no matches remaining